### PR TITLE
Locked up board.snakesOnlyGrid.

### DIFF
--- a/ai/Board.js
+++ b/ai/Board.js
@@ -76,6 +76,8 @@ module.exports = class Board {
 
         addSnakes(this.snakes, this.grid);
         addSnakes(this.snakes, this.snakesOnlyGrid);
+        Object.freeze(this.snakesOnlyGrid);
+        this.snakesOnlyGrid.forEach((row) => Object.freeze(row));
     }
 
     /** Creates a graph of the board.


### PR DESCRIPTION
Would be nice to do for board.grid, but code in topAI modifies it to add auras, and there are a chain of Board methods that are used in this code that don't really need to be board methods, but it would be a bit of a project to pull them out.